### PR TITLE
Specify when pushstate routing is set up

### DIFF
--- a/can-route-pushstate.js
+++ b/can-route-pushstate.js
@@ -21,10 +21,12 @@ var canEvent = require('can-event');
 var route = require('can-route');
 
 var hasPushstate = window.history && window.history.pushState;
-var isFileProtocol = window.location && window.location.protocol === 'file:';
+var location = route.location || window.location;
+var validProtocols = { 'http:': true, 'https:': true, '': true };
+var usePushStateRouting = hasPushstate && location && validProtocols[location.protocol];
 
 // Initialize plugin only if browser supports pushstate.
-if (!isFileProtocol && hasPushstate) {
+if (usePushStateRouting) {
 
 	// Registers itself within `route.bindings`.
 	route.bindings.pushstate = {

--- a/can-route-pushstate_test.js
+++ b/can-route-pushstate_test.js
@@ -11,9 +11,6 @@ if (window.history && history.pushState) {
 }
 
 function makeTest(mapModuleName){
-
-
-
 	QUnit.module("can/route/pushstate with "+mapModuleName, {
 		setup: function () {
 			route._teardown();
@@ -389,7 +386,7 @@ function makeTest(mapModuleName){
 	// Start steal-only
 	if (typeof steal !== 'undefined') {
 
-		var makeTestingIframe = function (callback) {
+		var makeTestingIframe = function (callback, testHTML) {
 			var iframe = document.createElement('iframe');
 
 			window.routeTestReady = function (iCanRoute, loc, history, win) {
@@ -406,7 +403,8 @@ function makeTest(mapModuleName){
 				});
 			};
 
-			iframe.src = "testing.html" + "?" + Math.random();
+			testHTML = testHTML || "testing.html";
+			iframe.src = testHTML + "?" + Math.random();
 			document.getElementById("qunit-fixture").appendChild(iframe);
 		};
 
@@ -918,6 +916,26 @@ function makeTest(mapModuleName){
 			bar: "def",
 			route: ":foo-:bar"
 		});
+	});
+
+	test("Binding not added if not using the http/s procotols", function () {
+		stop();
+
+		makeTestingIframe(function(info, done){
+			equal(info.route.defaultBinding, "hashchange", "using hashchange routing");
+			start();
+			done();
+		}, "testing-nw.html");
+	});
+
+	test("Binding is added if there is no protocol (can-simple-dom uses an empty string as the protocol)", function() {
+		stop();
+
+		makeTestingIframe(function(info, done){
+			equal(info.route.defaultBinding, "pushstate", "pushstate routing is used");
+			start();
+			done();
+		}, "testing-ssr.html");
 	});
 
 }

--- a/test/testing-nw.html
+++ b/test/testing-nw.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>can.route test page</title>
+</head>
+<body>
+<p>This is a dummy page to use<br/> for testing route goodness</p>
+
+<script type="text/javascript" src="../node_modules/steal/steal.js" main="@empty">
+System.import('can-route').then(function(route){
+	route.location = { protocol: "chrome-extension:" };
+
+	Promise.all([
+		System.import('can-route-pushstate/can-route-pushstate'),
+		System.import(window.parent.MAP_MODULE_NAME)
+	]).then(function(modules){
+		window.route = modules[0];
+		window.CanMap = modules[1];
+
+		setTimeout(function () {
+			window.parent.routeTestReady && window.parent.routeTestReady(route, window.location, window.history, window)
+		}, 30);
+	});
+})
+
+</script>
+
+</body>
+</html>

--- a/test/testing-ssr.html
+++ b/test/testing-ssr.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>can.route test page</title>
+</head>
+<body>
+<p>This is a dummy page to use<br/> for testing route goodness</p>
+
+<script type="text/javascript" src="../node_modules/steal/steal.js" main="@empty">
+System.import('can-route').then(function(route){
+	route.location = { protocol: "" };
+
+	Promise.all([
+		System.import('can-route-pushstate/can-route-pushstate'),
+		System.import(window.parent.MAP_MODULE_NAME)
+	]).then(function(modules){
+		window.route = modules[0];
+		window.CanMap = modules[1];
+
+		setTimeout(function () {
+			window.parent.routeTestReady && window.parent.routeTestReady(route, window.location, window.history, window)
+		}, 30);
+	});
+})
+
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This updates the logic that determines when pushstate routing is used.
Previously it was specifically avoided if using the file: protocol
because this is the protocol that Cordova and NW.js use. Now that NW.js
uses chrome-extension: as the protocol, the currently logic doesn't
work.

This makes the logic more flexible by having a whitelist of protocols
that are valid to set up pushstate routing. Those protocols are:

* http
* https
* (empty string) - This one is for done-ssr, because can-simple-dom
* doesn't have a protocol.

Fixes #29