### PR TITLE
Use can-util/dom/location/location

### DIFF
--- a/can-route-pushstate.js
+++ b/can-route-pushstate.js
@@ -16,14 +16,15 @@ var each = require('can-util/js/each/each');
 var makeArray = require('can-util/js/make-array/make-array');
 var diffObject = require('can-util/js/diff-object/diff-object');
 var namespace = require('can-util/namespace');
+var LOCATION = require('can-util/dom/location/location');
 
 var canEvent = require('can-event');
 var route = require('can-route');
 
 var hasPushstate = window.history && window.history.pushState;
-var location = route.location || window.location;
+var loc = LOCATION();
 var validProtocols = { 'http:': true, 'https:': true, '': true };
-var usePushStateRouting = hasPushstate && location && validProtocols[location.protocol];
+var usePushStateRouting = hasPushstate && loc && validProtocols[loc.protocol];
 
 // Initialize plugin only if browser supports pushstate.
 if (usePushStateRouting) {
@@ -90,9 +91,11 @@ if (usePushStateRouting) {
 				window.history[method] = function (state, title, url) {
 					// Avoid doubled history states (with pushState).
 					var absolute = url.indexOf("http") === 0;
-					var searchHash = window.location.search + window.location.hash;
+					var loc = LOCATION();
+					var searchHash = loc.search + loc.hash;
 					// If url differs from current call original histoy method and update `route` state.
-					if ((!absolute && url !== window.location.pathname + searchHash) || (absolute && url !== window.location.href + searchHash)) {
+					if ((!absolute && url !== loc.pathname + searchHash) ||
+						(absolute && url !== loc.href + searchHash)) {
 						originalMethods[method].apply(window.history, arguments);
 						route.setState();
 					}
@@ -121,6 +124,7 @@ if (usePushStateRouting) {
 		// Returns matching part of url without root.
 		matchingPartOfURL: function () {
 			var root = cleanRoot(),
+			  location = LOCATION(),
 				loc = (location.pathname + location.search),
 				index = loc.indexOf(root);
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "can-event": "^3.0.1",
     "can-route": "^3.0.0",
-    "can-util": "^3.0.1"
+    "can-util": "^3.3.0"
   },
   "devDependencies": {
     "can-define": "^1.0.1",

--- a/test/testing-nw.html
+++ b/test/testing-nw.html
@@ -7,8 +7,14 @@
 <p>This is a dummy page to use<br/> for testing route goodness</p>
 
 <script type="text/javascript" src="../node_modules/steal/steal.js" main="@empty">
-System.import('can-route').then(function(route){
-	route.location = { protocol: "chrome-extension:" };
+Promise.all([
+	System.import('can-route'),
+	System.import('can-util/dom/location/location')
+]).then(function(modules){
+	var route = modules[0];
+	var LOCATION = modules[1];
+
+	LOCATION({ protocol: "chrome-extension:" });
 
 	Promise.all([
 		System.import('can-route-pushstate/can-route-pushstate'),
@@ -21,7 +27,7 @@ System.import('can-route').then(function(route){
 			window.parent.routeTestReady && window.parent.routeTestReady(route, window.location, window.history, window)
 		}, 30);
 	});
-})
+});
 
 </script>
 

--- a/test/testing-ssr.html
+++ b/test/testing-ssr.html
@@ -7,8 +7,14 @@
 <p>This is a dummy page to use<br/> for testing route goodness</p>
 
 <script type="text/javascript" src="../node_modules/steal/steal.js" main="@empty">
-System.import('can-route').then(function(route){
-	route.location = { protocol: "" };
+Promise.all([
+	System.import('can-route'),
+	System.import('can-util/dom/location/location')
+]).then(function(modules){
+	var route = modules[0];
+	var LOCATION = modules[1];
+
+	LOCATION({ protocol: "" });
 
 	Promise.all([
 		System.import('can-route-pushstate/can-route-pushstate'),


### PR DESCRIPTION
This uses can-util/dom/location/location to get the `location` object.
This means that we always get the object lazily, as is needed for an SSR
use. Fixes #31