### PR TITLE
Landscaper: Remove deprecated can-util methods and replace with can-globals

### DIFF
--- a/can-route-pushstate.js
+++ b/can-route-pushstate.js
@@ -16,7 +16,7 @@ var each = require('can-util/js/each/each');
 var makeArray = require('can-util/js/make-array/make-array');
 var diffObject = require('can-util/js/diff-object/diff-object');
 var namespace = require('can-util/namespace');
-var LOCATION = require('can-util/dom/location/location');
+var LOCATION = require('can-globals/location/location');
 
 var canEvent = require('can-event');
 var route = require('can-route');

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "can-event": "^3.5.0",
     "can-route": "^3.1.0",
-    "can-util": "^3.9.0"
+    "can-util": "^3.9.0",
+    "can-globals": "^0.1.0"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",


### PR DESCRIPTION
This pull request was created with [Landscaper](https://github.com/bitovi/landscaper).
The following code mods were used to create this PR:

1. **https://gist.github.com/imaustink/d1faff15b89df8fb7964c5d5c3945e72**

Please review this PR carefully as Landscaper does not guarantee any code mod's quality.