### PR TITLE
Update dependency version of can-globals

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   ],
   "dependencies": {
     "can-event": "^3.5.0",
+    "can-globals": "^0.2.3",
     "can-route": "^3.1.0",
-    "can-util": "^3.9.0",
-    "can-globals": "^0.1.0"
+    "can-util": "^3.9.0"
   },
   "devDependencies": {
     "bit-docs": "0.0.8-0",


### PR DESCRIPTION
Fixes the tests by making the direct can-globals dep match what the other dependencies require.