### PR TITLE
Don’t preventDefault() when clicking a link that just changes the hash

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -10,6 +10,7 @@
 		"expect": true,
 		"module": true,
 		"ok": true,
+		"notOk": true,
 		"equal": true,
 		"notEqual": true,
 		"deepEqual": true,

--- a/can-route-pushstate.js
+++ b/can-route-pushstate.js
@@ -183,18 +183,25 @@ if (usePushStateRouting) {
 				if (node.pathname.indexOf(root) === 0) {
 
 					// Removes root from url.
-					var url = (node.pathname + node.search).substr(root.length);
+					var nodePathWithSearch = node.pathname + node.search;
+					var url = nodePathWithSearch.substr(root.length);
 					// If a route matches update the data.
 					var curParams = route.deparam(url);
 					if (curParams.hasOwnProperty('route')) {
 						// Makes it possible to have a link with a hash.
 						includeHash = true;
+
+						// We do not want to call preventDefault() if the link is to the
+						// same page and just a different hash; see can-route-pushstate#75
+						var windowPathWithSearch = window.location.pathname + window.location.search;
+						var shouldCallPreventDefault = nodePathWithSearch !== windowPathWithSearch || node.hash === window.location.hash;
+
 						window.history.pushState(null, null, node.href);
 
 						// Test if you can preventDefault
 						// our tests can't call .click() b/c this
 						// freezes phantom.
-						if (e.preventDefault) {
+						if (shouldCallPreventDefault && e.preventDefault) {
 							e.preventDefault();
 						}
 					}

--- a/can-route-pushstate_test.js
+++ b/can-route-pushstate_test.js
@@ -290,7 +290,7 @@ function makeTest(mapModuleName){
 		})
 	})
 
-	test("precident", function () {
+	test("precedent", function () {
 		route.routes = {};
 		route("{who}", {
 			who: "index"
@@ -320,7 +320,7 @@ function makeTest(mapModuleName){
 			"can.Control");
 	})
 
-	test("better matching precident", function () {
+	test("better matching precedent", function () {
 		route.routes = {};
 		route("{type}", {
 			who: "index"
@@ -547,6 +547,47 @@ function makeTest(mapModuleName){
 					iframe.parentNode.removeChild(iframe);
 
 				}, 100);
+			};
+			var iframe = document.createElement('iframe');
+			iframe.src = __dirname + "/test/testing.html";
+			document.getElementById('qunit-fixture').appendChild(iframe);
+		});
+
+		test("preventDefault not called when only the hash changes (can-route-pushstate#75)", function () {
+
+			stop();
+			window.routeTestReady = function (iCanRoute, loc, hist, win) {
+
+				iCanRoute(win.location.pathname, {
+					page: "index"
+				});
+
+				iCanRoute("{type}/{id}");
+				iCanRoute.ready();
+
+				var link = win.document.createElement("a");
+				link.href = "#hash-target";
+				link.innerHTML = "Click Me";
+
+				win.document.body.appendChild(link);
+
+				// Detect if can-route-pushstate’s click handler calls preventDefault by overriding it
+				var defaultPrevented = false;
+				link.addEventListener('click', function(event) {
+					event.preventDefault = function() {
+						defaultPrevented = true;
+					};
+				});
+
+				domDispatch.call(link, "click");
+
+				notOk(defaultPrevented, "preventDefault was not called");
+
+				equal(win.location.hash, "#hash-target", "includes hash");
+
+				start();
+
+				iframe.parentNode.removeChild(iframe);
 			};
 			var iframe = document.createElement('iframe');
 			iframe.src = __dirname + "/test/testing.html";


### PR DESCRIPTION
If the user clicks on a link that’s on the same page but just a different #hash, don’t prevent default so the browser can handle the click.

Fixes https://github.com/canjs/can-route-pushstate/issues/75