### PR TITLE
Improve click handling when a modifier key is held down

### DIFF
--- a/can-route-pushstate.js
+++ b/can-route-pushstate.js
@@ -22,6 +22,11 @@ var route = require('can-route');
 
 var hasPushstate = window.history && window.history.pushState;
 var isFileProtocol = window.location && window.location.protocol === 'file:';
+var clientPlatform = {
+	isMac: window.navigator.platform.match(/(Mac|iPhone|iPod|iPad)/i) ? true : false,
+	isWin: window.navigator.platform.match(/(Win)/i) ? true : false
+};
+
 
 // Initialize plugin only if browser supports pushstate.
 if (!isFileProtocol && hasPushstate) {
@@ -158,6 +163,19 @@ if (!isFileProtocol && hasPushstate) {
 		}
 	};
 
+	// ## altKeyPressed
+	
+	// Helper that examines event object for correct 
+	// alternative key press based on platform
+	var altKeyPressed = function (e) {
+		if (clientPlatform.isMac) {
+			return e.metaKey;
+		}
+		if (clientPlatform.isWin) {
+			return e.ctrlKey;
+		}
+	};
+
 	// ## anchorClickHandler
 
 	// Handler function for `click` events.
@@ -169,14 +187,8 @@ if (!isFileProtocol && hasPushstate) {
 			var linksHost = node.host || window.location.host;
 
 			// href has some JS in it, let it run
-			if(node.href.trim().indexOf('javascript') === 0) {
-				try {
-					eval(node.href);
-				}
-				catch (e) {
-					// Most likely safe to just let the click go through
-					return;
-				}
+			if(node.href === "javascript://") {
+				return;
 			}
 
 			// Do not push state if target is for blank window
@@ -185,7 +197,7 @@ if (!isFileProtocol && hasPushstate) {
 			}
 
 			// Do not push state if meta key was pressed, mimicing standard browser behavior
-			if (e.metaKey) {
+			if (altKeyPressed(e)) {
 				return;
 			}
 

--- a/can-route-pushstate.js
+++ b/can-route-pushstate.js
@@ -168,7 +168,24 @@ if (!isFileProtocol && hasPushstate) {
 			// Fix for IE showing blank host, but blank host means current host.
 			var linksHost = node.host || window.location.host;
 
-			if(node.href === "javascript://") {
+			// href has some JS in it, let it run
+			if(node.href.trim().indexOf('javascript') === 0) {
+				try {
+					eval(node.href);
+				}
+				catch (e) {
+					// Most likely safe to just let the click go through
+					return;
+				}
+			}
+
+			// Do not push state if target is for blank window
+			if(node.target === '_blank'){
+				return;
+			}
+
+			// Do not push state if meta key was pressed, mimicing standard browser behavior
+			if (e.metaKey) {
 				return;
 			}
 

--- a/can-route-pushstate.js
+++ b/can-route-pushstate.js
@@ -20,10 +20,6 @@ var domEvents = require('can-util/dom/events/events');
 require("can-util/dom/events/delegate/delegate");
 var route = require('can-route');
 
-var clientPlatform = {
-	isMac: window.navigator.platform.match(/(Mac|iPhone|iPod|iPad)/i) ? true : false,
-	isWin: window.navigator.platform.match(/(Win)/i) ? true : false
-};
 var hasPushstate = window.history && window.history.pushState;
 var loc = LOCATION();
 var validProtocols = { 'http:': true, 'https:': true, '': true };
@@ -37,17 +33,6 @@ var SimpleObservable = require("can-simple-observable");
 
 // Original methods on `history` that will be overwritten
 var methodsToOverwrite = ['pushState', 'replaceState'];
-
-// Helper that examines event object for correct
-// alternative key press based on platform
-var altKeyPressed = function (e) {
-	if (clientPlatform.isMac) {
-		return e.metaKey;
-	}
-	if (clientPlatform.isWin) {
-		return e.ctrlKey;
-	}
-};
 
 // Always returns clean root, without domain.
 var cleanRoot = function () {
@@ -165,8 +150,8 @@ canReflect.assign(PushstateObservable.prototype,{
 				return;
 			}
 
-			// Do not push state if meta key was pressed, mimicing standard browser behavior
-			if (altKeyPressed(e)) {
+			// Do not push state if meta key was pressed, mimicking standard browser behavior
+			if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
 				return;
 			}
 

--- a/can-route-pushstate_test.js
+++ b/can-route-pushstate_test.js
@@ -580,6 +580,82 @@ function makeTest(mapModuleName){
 			});
 		});
 
+		test("javascript: void(0) links get pushstated", function(){
+			stop();
+			makeTestingIframe(function (info, done) {
+				info.route(":type", { type: "yay" });
+				info.route.ready();
+
+
+				var window = info.window;
+				var link = window.document.createElement("a");
+				link.href = "javascript: void(0)";
+				link.innerHTML = "Click Me";
+
+				window.document.body.appendChild(link);
+				try {
+					domDispatch.call(link, "click");
+					ok(true, "Clicking javascript: void(0) anchor did not cause a security exception");
+				} catch(err) {
+					ok(false, "Clicking javascript: void(0) anchor caused a security exception");
+				}
+
+				start();
+				done();
+			});
+		});
+
+		test("links with target=_blank do not get pushstated", function(){
+			stop();
+			makeTestingIframe(function (info, done) {
+				info.route(":type", { type: "yay" });
+				info.route.ready();
+
+
+				var window = info.window;
+				var link = window.document.createElement("a");
+				link.href = "/yay";
+				link.target = "_blank";
+				link.innerHTML = "Click Me";
+
+				window.document.body.appendChild(link);
+				try {
+					domDispatch.call(link, "click");
+					ok(true, "Clicking anchor with blank target did not cause a security exception");
+				} catch(err) {
+					ok(false, "Clicking anchor with blank target caused a security exception");
+				}
+
+				start();
+				done();
+			});
+		});
+
+		test("clicking on links while holding meta key do not get pushstated", function(){
+			stop();
+			makeTestingIframe(function (info, done) {
+				info.route(":type", { type: "yay" });
+				info.route.ready();
+
+
+				var window = info.window;
+				var link = window.document.createElement("a");
+				link.href = "/heyo";
+				link.innerHTML = "Click Me";
+
+				window.document.body.appendChild(link);
+				try {
+					domDispatch.call(link, {type: 'click', metaKey: true});
+					ok(true, "Clicking anchor with blank target did not cause a security exception");
+				} catch(err) {
+					ok(false, "Clicking anchor with blank target caused a security exception");
+				}
+
+				start();
+				done();
+			});
+		});
+
 		if(window.parent === window) {
 			// we can't call back if running in multiple frames
 			test("no doubled history states (#656)", function () {


### PR DESCRIPTION
This replaces https://github.com/canjs/can-route-pushstate/pull/28

The only change from that PR is the removal of OS-dependent handling; now this package does the same as https://github.com/canjs/bit-docs-html-canjs/issues/203