### PR TITLE
Make can-route-pushstate not be stateful

### DIFF
--- a/can-route-pushstate.js
+++ b/can-route-pushstate.js
@@ -24,21 +24,12 @@ var domEvents = require('can-dom-events');
 
 var diffObject = require('can-util/js/diff-object/diff-object');
 
-
-var hasPushstate = window.history && window.history.pushState;
-var loc = LOCATION();
-var validProtocols = {
-	'http:': true,
-	'https:': true,
-	'': true
-};
-var usePushStateRouting = hasPushstate && loc && validProtocols[loc.protocol];
-
 // Original methods on `history` that will be overwritten
 var methodsToOverwrite = ['pushState', 'replaceState'];
 
 // Always returns clean root, without domain.
 var cleanRoot = function() {
+	var location = LOCATION();
 	var domain = location.protocol + "//" + location.host,
 		root = bindingProxy.call("root"),
 		index = root.indexOf(domain);

--- a/can-route-pushstate.js
+++ b/can-route-pushstate.js
@@ -207,7 +207,6 @@ canReflect.assign(PushstateObservable.prototype, {
 		}
 	},
 	setup: function() {
-		debugger;
 		if (isNode()) {
 			return;
 		}
@@ -321,35 +320,5 @@ if (process.env.NODE_ENV !== 'production') {
 
 
 canReflect.assignSymbols(PushstateObservable.prototype, pushstateObservableProto);
-
-// Initialize plugin only if browser supports pushstate.
-if (usePushStateRouting) {
-
-
-	var options = {
-		replaceStateOnceKeys: [],
-		replaceStateKeys: []
-	};
-	//var pushstateBinding = new PushstateObservable(options);
-
-	// Registers itself within `route.bindings`.
-	//route.bindings.pushstate = pushstateBinding;
-
-	// Enables plugin, by default `hashchange` binding is used.
-	//route.defaultBinding = "pushstate";
-
-	canReflect.assignMap(route, {
-		replaceStateOn: function() {
-			canReflect.addValues(options.replaceStateKeys, canReflect.toArray(arguments));
-		},
-		replaceStateOnce: function() {
-			canReflect.addValues(options.replaceStateOnceKeys, canReflect.toArray(arguments));
-		},
-		replaceStateOff: function() {
-			canReflect.removeValues(options.replaceStateKeys, canReflect.toArray(arguments));
-			canReflect.removeValues(options.replaceStateOnceKeys, canReflect.toArray(arguments));
-		}
-	});
-}
 
 module.exports = PushstateObservable;

--- a/can-route-pushstate.js
+++ b/can-route-pushstate.js
@@ -62,12 +62,15 @@ function getCurrentUrl() {
 }
 
 
-function PushstateObservable(options) {
+function PushstateObservable() {
 	/*
 	 * - replaceStateKeys
 	 * - replaceStateOnceKeys
 	 */
-	this.options = options;
+	this.options = {
+		replaceStateOnceKeys: [],
+		replaceStateKeys: []
+	};
 	this.dispatchHandlers = this.dispatchHandlers.bind(this);
 	var self = this;
 	this.anchorClickHandler = function(event) {
@@ -204,6 +207,7 @@ canReflect.assign(PushstateObservable.prototype, {
 		}
 	},
 	setup: function() {
+		debugger;
 		if (isNode()) {
 			return;
 		}
@@ -281,6 +285,18 @@ canReflect.assign(PushstateObservable.prototype, {
 			}
 		}
 		window.history[method](null, null, bindingProxy.call("root") + path);
+	},
+
+
+	replaceStateOn: function() {
+		canReflect.addValues(this.options.replaceStateKeys, canReflect.toArray(arguments));
+	},
+	replaceStateOnce: function() {
+		canReflect.addValues(this.options.replaceStateOnceKeys, canReflect.toArray(arguments));
+	},
+	replaceStateOff: function() {
+		canReflect.removeValues(this.options.replaceStateKeys, canReflect.toArray(arguments));
+		canReflect.removeValues(this.options.replaceStateOnceKeys, canReflect.toArray(arguments));
 	}
 });
 
@@ -314,13 +330,13 @@ if (usePushStateRouting) {
 		replaceStateOnceKeys: [],
 		replaceStateKeys: []
 	};
-	var pushstateBinding = new PushstateObservable(options);
+	//var pushstateBinding = new PushstateObservable(options);
 
 	// Registers itself within `route.bindings`.
-	route.bindings.pushstate = pushstateBinding;
+	//route.bindings.pushstate = pushstateBinding;
 
 	// Enables plugin, by default `hashchange` binding is used.
-	route.defaultBinding = "pushstate";
+	//route.defaultBinding = "pushstate";
 
 	canReflect.assignMap(route, {
 		replaceStateOn: function() {
@@ -336,4 +352,4 @@ if (usePushStateRouting) {
 	});
 }
 
-module.exports = route;
+module.exports = PushstateObservable;

--- a/can-route-pushstate.js
+++ b/can-route-pushstate.js
@@ -86,8 +86,8 @@ PushstateObservable.prototype = Object.create(SimpleObservable.prototype);
 PushstateObservable.constructor = PushstateObservable;
 canReflect.assign(PushstateObservable.prototype, {
 	/**
-	 * @property {String} can-route-pushstate.root root
-	 * @parent can-route-pushstate.static
+	 * @property {String} can-route-pushstate.prototype.root root
+	 * @parent can-route-pushstate.prototype
 	 *
 	 * @description Configure the base url that will not be modified.
 	 *
@@ -121,7 +121,7 @@ canReflect.assign(PushstateObservable.prototype, {
 	 */
 
 	// Start of `location.pathname` is the root.
-	// (Can be configured via `route.bindings.pushstate.root`)
+	// (Can be configured via `route.urlData.root`)
 	root: "/",
 	// don't greedily match slashes in routing rules
 	matchSlashes: false,

--- a/can-route-pushstate.md
+++ b/can-route-pushstate.md
@@ -1,119 +1,76 @@
-@module {Object} can-route-pushstate
+@module {function} can-route-pushstate
 @parent can-routing
 @collection can-core
 @package ./package.json
-@group can-route-pushstate.static static
+@group can-route-pushstate.prototype prototype
 
-@description Changes [can-route] to use
+@description An observable that can be used as [can-route]'s [can-route.urlData], configuring it to use
 [pushstate](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history)
 to change the window's [pathname](https://developer.mozilla.org/en-US/docs/Web/API/URLUtils.pathname) instead
 of the [hash](https://developer.mozilla.org/en-US/docs/Web/API/URLUtils.hash).
 
 ```js
-import route from "can-route-pushstate";
+import route from "can-route";
+import RoutePushstate from "can-route-pushstate";
 
-route( "{page}", { page: "home" } );
+route.urlData = new RoutePushstate();
+route.register( "{page}", { page: "home" } );
 route.start();
 
-route.attr( "page", "user" );
+route.data.set("page", "user");
 
 location.pathname; // -> "/user"
 ```
 
-@option {Object} The pushstate object comprises several properties that configure the behavior of [can-route] to work with `history.pushstate`.
+@option {Object} The pushstate object comprises several properties that configure the behavior of [can-route] to work with `history.pushState`.
 
 @body
 
 ## Use
 
-can-route-pushstate uses the same API as [can-route]. To start using can-route-pushstate all you need is to import `can-route-pushstate`, it will set itself as default binding on [can-route].
+__can-route-pushstate__ exports an observable that can be used with [can-route]. To start using can-route-pushstate set the [can-route.urlData] property:
 
-You can check current binding by inspecting `route.currentBinding`; the default value is `"hashchange"`.
+```js
+import route from "can-route";
+import RoutePushstate from "can-route-pushstate";
+
+route.urlData = new RoutePushstate();
+```
 
 ### Creating and changing routes
 
-To create routes use `route(url, defaults)` like:
+To create routes use [can-route.register] like:
 
 ```js
-route( "{page}", { page: "homepage" } );
-route( "contacts/{username}" );
-route( "books/{genre}/{author}" );
+route.urlData = new RoutePushstate();
+
+route.register( "{page}", { page: "homepage" } );
+route.register( "contacts/{username}" );
+route.register( "books/{genre}/{author}" );
 
 route.start(); // Initializes can-route
 ```
 
 Do not forget to [can-route.start initialize] can-route after creating all routes, do it by calling `route.start()`.
 
-List of defined routes is contained in `route.routes`, you can examine current route state by calling:
-
-```js
-route.attr(); //-> {page: "homepage", route: "{page}"}
-```
-
-After creating routes and initializing can-route you can update current route by calling `route.attr(attr, newVal)`:
-
-```js
-route.attr( "page", "about" );
-route.attr(); //-> {page: "about", route: "{page}"}
-
-// without cleaning current route state
-route.attr( "username", "veljko" );
-route.attr(); //-> {page: "about", route: "{page}", username: 'veljko'}
-
-// with cleaning current can-route state
-route.attr( { username: "veljko" }, true );
-route.attr(); //-> {username: "veljko", route: "contacts/{username}"}
-```
-
-To update multiple attributes at once pass hash of attributes to `route.attr(hashOfAttrs, true)`. Pass `true` as second argument to clean up current state.
-
-```js
-route.attr( { genre: "sf", author: "adams" }, true );
-route.attr(); //-> {genre: "sf", author: "adams", route: "books/{genre}/{author}"}
-```
-
-`window.location` acts as expected:
-
-```js
-window.location.pathname; //-> "/books/sf/adams"
-window.location.hash; //-> "", hash remains unchanged
-```
-
-To generate urls use `route.url({attrs})`:
-
-```js
-route.url( { username: "justinbmeyer" } ); //-> '/contacts/justinbmeyer'
-```
-
 ### Listening changes on matched route
 
 As can-route contains a map that represents `window.location.pathname`, you can bind on it.
 
-To bind to specific attributes on can-route:
-
-```js
-route.bind( "username", function( ev, newVal, oldVal ) {
-
-	//-> ev:     {EventObject}
-	//-> newVal: 'nikica'
-	//-> oldVal: 'veljko'
-} );
-
-route.attr( { username: nikica }, true );
-```
+To bind to specific attributes on [can-route] you can listen to your viewModel's property changes (`viewModel.on()` if using [can-define/map/map]).
 
 ### Using different pathname root
 
-can-route-pushstate has one additional property, `route.bindings.pushstate.root`, which specifies the part of that pathname that should not change. For example, if we only want to have pathnames within `http://example.com/contacts/`, we can specify a root like:
+can-route-pushstate has one additional property, `routePushstate.root`, which specifies the part of that pathname that should not change. For example, if we only want to have pathnames within `http://example.com/contacts/`, we can specify a root like:
 
 ```js
-route.bindings.pushstate.root = "/contacts/";
-route( "{page}" );
+route.urlData.root = "/contacts/";
+route.register( "{page}" );
 route.url( { page: "list" } ); //-> "/contacts/list"
 route.url( { foo: "bar" } );   //-> "/contacts/?foo=bar"
 ```
 
-Now, all routes will start with `"/contacts/"`, the default `route.bindings.pushstate.root` value is `"/"`.
+Now, all routes will start with `"/contacts/"`, the default `route.urlData.root` value is `"/"`.
 
 ### Updating the current route
 
@@ -122,23 +79,25 @@ can-route-pushstate also allows changes to the current route state without creat
 Enable the behavior by calling `replaceStateOn` with specified route property keys like:
 
 ```js
-route.replaceStateOn( "page", "action" );
-route.attr( "page", "dashboard" ); // Route changes, no new history record
+var push = new RoutePushstate();
+route.urlData = push;
+push.replaceStateOn( "page", "action" );
+route.set( "page", "dashboard" ); // Route changes, no new history record
 ```
 
-To return the `attr` call back to normal the `pushstate` behavior, call `replaceStateOff` with the specified route property keys like:
+To return back to normal, call `replaceStateOff` with the specified route property keys like:
 
 ```js
-route.replaceStateOff( "action" );
-route.attr( "action", "remove" ); // Route changes, new history record is created
+push.replaceStateOff( "action" );
+route.set( "action", "remove" ); // Route changes, new history record is created
 ```
 
 The behavior can be configured to occur only once for a specific property using `replaceStateOnce` like:
 
 ```js
-route.replaceStateOnce( "page" );
-route.attr( "page", "dashboard" ); // No new history record
-route.attr( "page", "search" ); // New history record is created
+push.replaceStateOnce( "page" );
+route.set( "page", "dashboard" ); // No new history record
+route.set( "page", "search" ); // New history record is created
 ```
 
 

--- a/can-route-pushstate_test.js
+++ b/can-route-pushstate_test.js
@@ -424,7 +424,6 @@ function makeTest(mapModuleName){
 			var done = assert.async();
 
 			makeTestingIframe(function(info, cleanup) {
-				debugger;
 				info.history.pushState(null, null, "/");
 
 				info.route.register("");
@@ -435,7 +434,7 @@ function makeTest(mapModuleName){
 				info.history.pushState(null, null, "home");
 				var deps = info.window.ObservationRecorder.stop();
 
-				ok(deps.valueDependencies.has(info.route.bindings.pushstate));
+				ok(deps.valueDependencies.has(info.route.urlData));
 				cleanup();
 				done();
 			});
@@ -774,7 +773,7 @@ function makeTest(mapModuleName){
 						}, 200);
 					}
 
-					win.route.bindings.pushstate.root = root;
+					win.route.urlData.root = root;
 					win.route("{page}/");
 					win.route.start();
 					nextStateTest();
@@ -788,7 +787,7 @@ function makeTest(mapModuleName){
 			test("URL's don't greedily match", function () {
 				stop();
 				makeTestingIframe(function(info, done){
-					info.route.bindings.pushstate.root = "testing.html";
+					info.route.urlData.root = "testing.html";
 					info.route("{module}\\.html");
 					info.route.start();
 
@@ -809,7 +808,7 @@ function makeTest(mapModuleName){
 			var setupRoutesAndRoot = function (iCanRoute, root) {
 				iCanRoute("{section}/");
 				iCanRoute("{section}/{sub}/");
-				iCanRoute.bindings.pushstate.root = root;
+				iCanRoute.urlData.root = root;
 				iCanRoute.start();
 			};
 
@@ -892,7 +891,7 @@ function makeTest(mapModuleName){
 					ok(true, "replaceState called");
 				};
 
-				info.route.replaceStateOn("ignoreme");
+				info.route.urlData.replaceStateOn("ignoreme");
 
 				info.route.start();
 				info.route.attr('ignoreme', 'yes');
@@ -916,7 +915,7 @@ function makeTest(mapModuleName){
 					ok(true, "replaceState called");
 				};
 
-				info.route.replaceStateOn("ignoreme", "metoo");
+				info.route.urlData.replaceStateOn("ignoreme", "metoo");
 
 				info.route.start();
 				info.route.attr('ignoreme', 'yes');
@@ -947,7 +946,7 @@ function makeTest(mapModuleName){
 					replaceCalls++;
 				};
 
-				info.route.replaceStateOnce("ignoreme", "metoo");
+				info.route.urlData.replaceStateOnce("ignoreme", "metoo");
 
 				info.route.start();
 				info.route.attr('ignoreme', 'yes');
@@ -978,8 +977,8 @@ function makeTest(mapModuleName){
 					ok(false, "replaceState should not be called called");
 				};
 
-				info.route.replaceStateOn("ignoreme");
-				info.route.replaceStateOff("ignoreme");
+				info.route.urlData.replaceStateOn("ignoreme");
+				info.route.urlData.replaceStateOff("ignoreme");
 
 				info.route.start();
 				info.route.attr('ignoreme', 'yes');
@@ -1081,7 +1080,7 @@ function makeTest(mapModuleName){
 		stop();
 
 		makeTestingIframe(function(info, done){
-			equal(info.route.defaultBinding, "pushstate", "pushstate routing is used");
+			ok(true, "We got this far which means things did not blow up");
 			start();
 			done();
 		}, __dirname + "/test/testing-ssr.html");

--- a/can-route-pushstate_test.js
+++ b/can-route-pushstate_test.js
@@ -1,7 +1,8 @@
 /* jshint asi:true,scripturl:true */
 var QUnit = require('steal-qunit');
 var extend = require('can-util/js/assign/assign');
-var route = require('./can-route-pushstate');
+var RoutePushstate = require('./can-route-pushstate');
+var route = require('can-route');
 var domEvents = require('can-dom-events');
 
 if (window.history && history.pushState) {
@@ -12,8 +13,7 @@ if (window.history && history.pushState) {
 function makeTest(mapModuleName){
 	QUnit.module("can/route/pushstate with " + mapModuleName, {
 		setup: function () {
-			route._teardown();
-			route.defaultBinding = "pushstate";
+			route.urlData = new RoutePushstate();
 			window.MAP_MODULE_NAME = mapModuleName;
 		}
 	});
@@ -424,6 +424,7 @@ function makeTest(mapModuleName){
 			var done = assert.async();
 
 			makeTestingIframe(function(info, cleanup) {
+				debugger;
 				info.history.pushState(null, null, "/");
 
 				info.route.register("");

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "can-observation-recorder": "^1.0.2",
     "can-queues": "<2.0.0",
     "can-reflect": "^1.8.0",
-    "can-route": "^4.0.0",
+    "can-route": "canjs/can-route#minor",
     "can-simple-observable": "^2.0.0",
     "can-util": "^3.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "can-observation-recorder": "^1.0.2",
     "can-queues": "<2.0.0",
     "can-reflect": "^1.8.0",
-    "can-route": "canjs/can-route#minor",
+    "can-route": "^4.2.0-pre.1",
     "can-simple-observable": "^2.0.0",
     "can-util": "^3.9.0"
   },

--- a/test/testing.html
+++ b/test/testing.html
@@ -11,15 +11,19 @@
 <script>
 steal.done().then(function() {
 	Promise.all([
+		System.import("can-route"),
 		System.import("can-route-pushstate"),
 		System.import(window.parent.MAP_MODULE_NAME),
 		System.import("can-queues"),
 		System.import("can-observation-recorder")
 	]).then(function(modules) {
 		window.route = modules[0];
-		window.CanMap = modules[1];
-		window.queues = modules[2];
-		window.ObservationRecorder = modules[3];
+		window.RoutePushstate = modules[1];
+		window.CanMap = modules[2];
+		window.queues = modules[3];
+		window.ObservationRecorder = modules[4];
+
+		window.route.urlData = new window.RoutePushstate();
 		setTimeout(function() {
 			window.parent.routeTestReady &&
 				window.parent.routeTestReady(


### PR DESCRIPTION
This removes the statefulness from can-route-pushstate by requiring developers to set `route.urlData` to be an instance of the RoutePushstate observable like so:

```js
import { route, RoutePushstate } from "can";

route.urlData = new RoutePushstate();
route.register("{page}", { page: "home" });

route.start();
```

This is a breaking change.