### PR TITLE
earlier preventDefault call during anchorHandler

### DIFF
--- a/can-route-pushstate.js
+++ b/can-route-pushstate.js
@@ -192,16 +192,16 @@ canReflect.assign(PushstateObservable.prototype, {
 						// same page and just a different hash; see can-route-pushstate#75
 						var windowPathWithSearch = window.location.pathname + window.location.search;
 						var shouldCallPreventDefault = nodePathWithSearch !== windowPathWithSearch || node.hash === window.location.hash;
-
-						// Now update window.location
-						window.history.pushState(null, null, node.href);
-
+						
 						// Test if you can preventDefault
 						// our tests can't call .click() b/c this
 						// freezes phantom.
 						if (shouldCallPreventDefault && e.preventDefault) {
 							e.preventDefault();
 						}
+						
+						// Now update window.location
+						window.history.pushState(null, null, node.href);
 					}
 				}
 			}


### PR DESCRIPTION
call preventDefault before potential errors occur during pushState changes. fixes #115 