### PR TITLE
Added test preventDefault was called when pushState throws an error

### DIFF
--- a/can-route-pushstate.js
+++ b/can-route-pushstate.js
@@ -193,6 +193,7 @@ canReflect.assign(PushstateObservable.prototype, {
 						var windowPathWithSearch = window.location.pathname + window.location.search;
 						var shouldCallPreventDefault = nodePathWithSearch !== windowPathWithSearch || node.hash === window.location.hash;
 						
+
 						// Test if you can preventDefault
 						// our tests can't call .click() b/c this
 						// freezes phantom.
@@ -202,6 +203,7 @@ canReflect.assign(PushstateObservable.prototype, {
 						
 						// Now update window.location
 						window.history.pushState(null, null, node.href);
+
 					}
 				}
 			}

--- a/can-route-pushstate.js
+++ b/can-route-pushstate.js
@@ -192,16 +192,16 @@ canReflect.assign(PushstateObservable.prototype, {
 						// same page and just a different hash; see can-route-pushstate#75
 						var windowPathWithSearch = window.location.pathname + window.location.search;
 						var shouldCallPreventDefault = nodePathWithSearch !== windowPathWithSearch || node.hash === window.location.hash;
-
-						// Now update window.location
-						window.history.pushState(null, null, node.href);
-
+						
 						// Test if you can preventDefault
 						// our tests can't call .click() b/c this
 						// freezes phantom.
 						if (shouldCallPreventDefault && e.preventDefault) {
 							e.preventDefault();
 						}
+						
+						// Now update window.location
+						window.history.pushState(null, null, node.href);
 					}
 				}
 			}

--- a/can-route-pushstate_test.js
+++ b/can-route-pushstate_test.js
@@ -1103,4 +1103,49 @@ function makeTest(mapModuleName){
 		});
 	});
 
+	test("Check if prevent default is called when pushState throws an error (#116)", function() {
+		stop();
+
+		makeTestingIframe(function(info, done){
+
+			var win = info.window;
+
+			// matching default route to test url.
+			info.route(win.location.pathname, {
+				page: "index"
+			});
+
+			info.route("{type}/{id}");
+
+			info.route.start();
+
+			// creating link that we'll test the prevent default
+			var link = win.document.createElement("a");
+			link.href = "/articles/17";
+			link.innerHTML = "Click Me";
+			win.document.body.appendChild(link);
+
+			info.route._onStartComplete = function() {
+				var event = win.document.createEvent('HTMLEvents');
+
+				event.preventDefault = function() {
+					QUnit.ok(true, 'prevent default is called');
+				}
+
+				// Simulate clicking the link to check if preventDefault is called.
+				event.initEvent('click', true, true);
+
+				info.history.pushState = function () {
+					throw new Error("an error happened in pushState");
+				};
+
+				try {
+					link.dispatchEvent(event);
+				} finally {
+					start();
+					done();
+				}
+			}
+		});
+	});
 }


### PR DESCRIPTION
tests #116 
fixes #115
Check if preventDefault was called when pushState throws an error.

Note: this changes the user experience, it will have the user click a link and never route to a new page.