### PR TITLE
Fix test failing in Safari

### DIFF
--- a/can-route-pushstate-iframe-test.js
+++ b/can-route-pushstate-iframe-test.js
@@ -547,33 +547,29 @@ function makeTest(mapModuleName){
 
 			var next = function () {
 				makeTestingIframe(function (info, done) {
-
-					var timer;
 					info.route.serializedCompute.bind("change", function () {
-						clearTimeout(timer);
-						timer = setTimeout(function () {
-							// deepEqual doesn't like to compare objects from different contexts
-							// so we copy it
-							var obj = extend({}, info.route.attr());
+						// deepEqual doesn't like to compare objects from different contexts
+						// so we copy it
+						var obj = extend({}, info.route.attr());
 
-							deepEqual(obj, {
-								section: "something",
-								sub: "test",
-							}, "route's data is correct");
+						deepEqual(obj, {
+							section: "something",
+							sub: "test",
+						}, "route's data is correct");
 
-							equal(info.route.matched(), "{section}/{sub}/",
-								"route's matched property is correct");
+						equal(info.route.matched(), "{section}/{sub}/",
+							"route's matched property is correct");
 
-							done();
-							start();
-						}, 10);
-
+						done();
+						start();
 					});
 
 					setupRoutesAndRoot(info.route, "/app/");
 					var link = createLink(info.window, "/app/something/test/");
-
 					domEvents.dispatch(link, "click");
+
+
+
 				});
 			};
 		});

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
     "can-observation-recorder": "^1.0.2",
     "can-queues": "<2.0.0",
     "can-reflect": "^1.8.0",
-    "can-route": "^4.2.0-pre.1",
+    "can-route": "^4.3.12",
     "can-simple-observable": "^2.0.0",
     "can-diff": "<2.0.0"
   },
   "devDependencies": {
     "can-assign": "<2.0.0",
-    "can-define": "^2.0.0",
+    "can-define": "^2.6.0",
     "can-map": "^4.0.0",
     "detect-cyclic-packages": "^1.1.0",
     "jshint": "^2.9.1",


### PR DESCRIPTION
This fixes a test that was failing in Safari caused by a setTimeout.
This caused problems in Safari because it will navigate the page before
the setTimeout fires.