### PR TITLE
Prevent tearing down history methods in Node

### DIFF
--- a/can-route-pushstate.js
+++ b/can-route-pushstate.js
@@ -19,6 +19,8 @@ var ObservationRecorder = require("can-observation-recorder");
 
 var isNode = require('can-globals/is-node/is-node');
 var LOCATION = require('can-globals/location/location');
+var getDocument = require('can-globals/document/document');
+var getGlobal = require('can-globals/global/global');
 
 var domEvents = require('can-dom-events');
 
@@ -239,6 +241,13 @@ canReflect.assign(PushstateObservable.prototype, {
 		domEvents.addEventListener(window, 'popstate', this.dispatchHandlers);
 	},
 	teardown: function() {
+		if(isNode()) {
+			return;
+		}
+
+		var document = getDocument();
+		var window = getGlobal();
+
 		domEvents.removeDelegateListener(document.documentElement, 'click', 'a', this.anchorClickHandler);
 
 		canReflect.eachKey(methodsToOverwrite, function(method) {

--- a/can-route-pushstate_test.js
+++ b/can-route-pushstate_test.js
@@ -3,6 +3,7 @@ var QUnit = require('steal-qunit');
 var RoutePushstate = require('./can-route-pushstate');
 var route = require('can-route');
 require("./can-route-pushstate-iframe-test");
+var globals = require('can-globals');
 
 if (window.history && history.pushState) {
 	makeTest("can-map");
@@ -445,6 +446,26 @@ function makeTest(mapModuleName){
 			foo: "abc",
 			bar: "def"
 		});
+	});
+
+	test("teardown in Node", function() {
+		var global = globals.getKeyValue('global');
+		var document = globals.getKeyValue('document');
+		var isNode = globals.getKeyValue('isNode');
+
+		try {
+			globals.setKeyValue('isNode', true);
+			route.urlData.teardown();
+
+			QUnit.ok(true, "Did not attempt to teardown in Node");
+		} catch(e) {
+			QUnit.ok(false, "Tried to teardown in Node");
+		}
+		finally {
+			globals.setKeyValue('global', global);
+			globals.setKeyValue('document', document);
+			globals.setKeyValue('isNode', isNode);
+		}
 	});
 
 }


### PR DESCRIPTION
In `setup()` event listeners are not added if running in Node. To match
we should do the same in `teardown()`.

This became a problem in 5.0 because calling `urlData = new
RoutePushstate()` calls teardown(), whereas previously it was never
called. This fixes https://github.com/donejs/donejs/issues/1116