### PR TITLE
126 documentation updates

### DIFF
--- a/can-route-pushstate.js
+++ b/can-route-pushstate.js
@@ -78,51 +78,6 @@ function PushstateObservable() {
 PushstateObservable.prototype = Object.create(SimpleObservable.prototype);
 PushstateObservable.constructor = PushstateObservable;
 canReflect.assign(PushstateObservable.prototype, {
-	/**
-	 * @property {String} can-route-pushstate.prototype.root root
-	 * @parent can-route-pushstate.prototype
-	 *
-	 * @description Configure the base url that will not be modified.
-	 *
-	 * @option {String} Represents the base url that pushstate will prepend to all
-	 * routes.  `root` defaults to: `"/"`.
-	 *
-	 * @body
-	 *
-	 * ## Use
-	 *
-	 * By default, a route like:
-	 *
-	 * ```js
-	 * route.urlData = new RoutePushstate();
-	 * route.register( "{type}/{id}" );
-	 * ```
-	 *
-	 * Matches URLs like:
-	 *
-	 * ```
-	 * http://domain.com/contact/5
-	 * ```
-	 *
-	 * But sometimes, you only want to match pages within a certain directory.  For
-	 * example, an application that is a filemanager.  You might want to
-	 * specify root and routes like:
-	 *
-	 * ```js
-	 * route.urlData = new RoutePushstate();
-	 * route.urlData.root = "/filemanager/";
-	 * route.register( "file-{fileId}" );
-	 * route.register( "folder-{fileId}" );
-	 * ```
-	 *
-	 * Which matches URLs like:
-	 *
-	 * ```
-	 * http://domain.com/filemanager/file-34234
-	 * ```
-	 *
-	 */
-
 	// Start of `location.pathname` is the root.
 	// (Can be configured via `route.urlData.root`)
 	root: "/",

--- a/can-route-pushstate.md
+++ b/can-route-pushstate.md
@@ -4,12 +4,15 @@
 @package ./package.json
 @group can-route-pushstate.prototype prototype
 
-@description An observable that can be used as [can-route]'s [can-route.urlData].
+@description Make [can-route] update the
+url's [https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/pathname pathname] with
+[https://developer.mozilla.org/en-US/docs/Web/API/History pushState].
 
 @type {RoutePushstate}
 
-  __can-route-pushstate__ exports a `RoutePushstate` constructor function. That constructor function can be used to create an observable that can be used with [can-route]. It configures [can-route] to use [pushState](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history)
-  to change the window's [pathname](https://developer.mozilla.org/en-US/docs/Web/API/URLUtils.pathname) instead
+  __can-route-pushstate__ exports a `RoutePushstate` constructor function. That constructor function creates observables that are
+  two-way bound to the browser's url. When the [can-route.urlData route.urlData] is set to one of those observabes, [can-route]
+  will window's [pathname](https://developer.mozilla.org/en-US/docs/Web/API/URLUtils.pathname) instead
   of the [hash](https://developer.mozilla.org/en-US/docs/Web/API/URLUtils.hash).
 
   To start using can-route-pushstate set the [can-route.urlData route.urlData] property:
@@ -31,8 +34,6 @@
   </script>
   ```
   @codepen
-
-  @type {Object} The pushstate object comprises several properties that configure the behavior of [can-route] to work with `history.pushstate`.
 
 @body
 
@@ -148,7 +149,7 @@ route.register("{page}");
 route.start();
 
 // New history record is created
-route.data.set( "page", "home" ); 
+route.data.set( "page", "home" );
 
 // Dashboard will not show up when you click back
 setTimeout(() => {

--- a/can-route-pushstate.md
+++ b/can-route-pushstate.md
@@ -269,7 +269,26 @@ setTimeout(() => {
 @codepen
 @hightlight 21
 
+## Making reload work
 
+The reload button typically will __not__ work by default in a website that uses `pushState`.  Developers typically
+need to:
+
+- Make sure the server respond with HTML for all URLs that a user might navigate to.  For example: `/about` and `tournaments/2018/games/4`.
+- The HTML and JavaScript loaded by those pages references all resources correctly.  For example:
+  - An image at `/about` might be referenced like `<img src="./static/img/logo.png"/>`.
+  - But the same image at `tournaments/2018/games/4` would need to be referenced like `<img src="../../../static/img/logo.png"/>`
+
+One option is to use only absolute paths.  For example:
+
+- An image at `/about` would be referenced like `<img src="/static/img/logo.png"/>`.
+- The same image at `tournaments/2018/games/4` would need be referenced like `<img src="/static/img/logo.png"/>`
+
+The problem with this approach is that your app is not as easily transportable.  For example, it couldn't easily be moved from
+`http://yourdomain.com` to
+`http://yourdomain.com/app/your-app`.
+
+For supporting relative paths, you can use [can-join-uris] and [can-stache.helpers.joinBase].
 
 ## Planning route structure
 

--- a/can-route-pushstate.md
+++ b/can-route-pushstate.md
@@ -5,17 +5,19 @@
 @group can-route-pushstate.prototype prototype
 
 @description Make [can-route] update the
-url's [https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/pathname pathname] with
+browser's location with
 [https://developer.mozilla.org/en-US/docs/Web/API/History pushState].
 
 @type {RoutePushstate}
 
   __can-route-pushstate__ exports a `RoutePushstate` constructor function. That constructor function creates observables that are
   two-way bound to the browser's url. When the [can-route.urlData route.urlData] is set to one of those observabes, [can-route]
-  will window's [pathname](https://developer.mozilla.org/en-US/docs/Web/API/URLUtils.pathname) instead
+  will update the window's [pathname](https://developer.mozilla.org/en-US/docs/Web/API/URLUtils.pathname) and
+  [search](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/search) instead
   of the [hash](https://developer.mozilla.org/en-US/docs/Web/API/URLUtils.hash).
 
-  To start using can-route-pushstate set the [can-route.urlData route.urlData] property:
+  To start using `can-route-pushstate` set the [can-route.urlData route.urlData] property
+  as follows:
 
   ```html
   <mock-url pushstate:from="true"></mock-url>
@@ -38,6 +40,111 @@ url's [https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtil
 @body
 
 ## Use
+
+The following shows a basic `RoutePushstate` setup within an application
+component.  The example:
+
+- Create links using [can-stache-route-helpers.routeUrl] like `/home`, `/dogs`, and `/cats`.
+- When users click on those links, [history.pushState()](https://developer.mozilla.org/en-US/docs/Web/API/History_API)
+  will update the URL.
+- When the url changes, `routeData.page` changes, updating the `<h1>` element.
+
+
+```html
+<mock-url pushstate:from="true"></mock-url>
+<my-demo></my-demo>
+<script type="module">
+import {route, RoutePushstate, Component} from "can";
+import "//unpkg.com/mock-url@5";
+
+Component.extend({
+	tag: "my-demo",
+	view: `
+		<h1>{{ this.routeData.page }}</h1>
+		<p><a href="{{routeUrl(page='home')}}">home</a></p>
+		<p><a href="{{routeUrl(page='dogs')}}">dogs</a></p>
+		<p><a href="{{routeUrl(page='cats')}}">cats</a></p>
+	`,
+	ViewModel: {
+		routeData: {
+			default(){
+				route.urlData = new RoutePushstate();
+				route.register( "{page}", {page: "home"} );
+				route.start(); // Initializes can-route
+				return route.data;
+			}
+		}
+	}
+});
+</script>
+```
+@codepen
+@highlight 10,11,18
+
+If you haven't already, please read the [guides/routing] guide. It explains
+how [can-route] works.  And while the guide show hashchange-based routing,
+your app should work the same way regardless if hashchange or pushstate routing is
+used.
+
+## Differences between pushState and hashchange based routing
+
+The biggest difference between using `RoutePushstate` and the default [can-route-hash hashchange routing] is
+that:
+
+- `RoutePushstate` responds to and updates the _pathname_ and _search_ part of the browser's [location](https://developer.mozilla.org/en-US/docs/Web/API/Location).
+- `RouteHash` responds to and updates the _hash_ part of the browser's [location](https://developer.mozilla.org/en-US/docs/Web/API/Location).
+
+For a url like `http://canjs.com/doc/can-route-pushstate.html?view=mobile#Use`:
+
+- _pathname_ is `/canjs/doc/can-route-pushstate.html`
+- _search_ is `?view=mobile`
+- _hash_ is `#Use`
+
+`RoutePushstate` will only update [can-route.data route.data] with values from the _pathname_ and _search_. The _hash_ part of the
+url is ignored but not lost. This is discussed at the bottom of this section.
+
+[can-route.register route.register]-ed rules match the _pathname_. For example, if your app is running on `site.com`,
+the following shows what urls are matched:
+
+```js
+route.register("")
+//  matches http://site.com
+//          http://site.com/
+//          http://site.com?key=value
+//          http://site.com/?key=value
+
+route.register("{page}")
+//  matches http://site.com/cats
+//          http://site.com/dogs
+//          http://site.com/dogs?key=value
+
+route.register("monkeys/{monkeyId}")
+//  matches http://site.com/monkeys/5
+//          http://site.com/monkeys/5?key=value
+```
+
+> Notice that `RoutePushstate` matches registered routing rules against against the entire _pathname_.  This can be changed by setting
+> [can-route-pushstate.prototype.root].
+
+The _search_ part of the url is used to add additional values to [can-route.data route.data]. The following example
+shows the values in _search_ being added to [can-route.data route.data]:
+
+
+```js
+import {route, RoutePushstate} from "can";
+
+history.pushState({}, "", "/page-value?keyA=valueA&keyB=valueB");
+
+route.urlData = new RoutePushstate();
+route.register("{page}");
+route.start();
+
+console.log( route.data ) //-> {page: "page-value", keyA: "valueA", keyB: "valueB"}
+```
+@codepen
+
+
+
 
 ### Creating and changing routes
 
@@ -65,13 +172,8 @@ route.data.username = "JustinMeyer";
 
 Do not forget to [can-route.start initialize] can-route after creating all routes, do it by calling [can-route.start `route.start()`].
 
-### Listening changes on matched route
 
-As can-route contains a map that represents `window.location.pathname`, you can bind on it.
-
-To bind to specific attributes on [can-route] you can listen to your viewModel's property changes (`viewModel.on()` if using [can-define/map/map]).
-
-### Using different pathname root
+## Using a different pathname root
 
 `can-route-pushstate` has one additional property, [can-route-pushstate.prototype.root], which specifies the part of that pathname that should not change. For example, if we only want to have pathnames within `http://example.com/contacts/`, we can specify a root like:
 
@@ -93,7 +195,7 @@ console.log( params ); //-> "/contacts/?foo=bar"
 
 Now, all routes will start with `"/contacts/"`. The default [can-route-pushstate.prototype.root] value is `"/"`.
 
-### Updating the current route
+## Using replaceState instead of pushState
 
 [can-route-pushstate] also allows changes to the current route state without creating a new history entry. This behavior can be controlled using the [can-route-pushstate.prototype.replaceStateOn `replaceStateOn`], [can-route-pushstate.prototype.replaceStateOff `replaceStateOff`], and [can-route-pushstate.prototype.replaceStateOnce `replaceStateOnce`] methods.
 
@@ -168,6 +270,7 @@ setTimeout(() => {
 @hightlight 21
 
 
+
 ## Planning route structure
 
 Complications can arise if your route structure mimics the folder structure inside your app's public directory.  For example, if you have a folder structure like the one in this url for your admin app...
@@ -175,3 +278,11 @@ Complications can arise if your route structure mimics the folder structure insi
 `/admin/users/list.js`
 
 ... using a route of /admin/users on the same page that uses the list.js file will require the use of a trailing slash on all routes and links.  The browser already learned that '/admin/users' is folder.  Because folders were originally denoted by a trailing slash in a url, the browser will correct the url to be '/admin/users/'.  While it is possible to add the trailing slash in routes and listen for them, any link to the page that omits the trailing slash will not trigger the route handler.
+
+## How it works
+
+On a high-level, `can-route-pushstate` creates an observable type that changes when `history.pushState` is called.  It does this by:
+
+1. Listening to all anchor element (`<a>`) clicks. If the anchor's `.href` matches a [can-route.rule], call `history.pushState`.
+1. Overwriting `history.pushState` to dispatch the observable's event handlers.  This signals a change in the  
+   observable has happened. (It also overwrites `history.replaceState` and listens to `popstate` events).

--- a/can-route-pushstate.md
+++ b/can-route-pushstate.md
@@ -202,7 +202,7 @@ The urls returned by `getLocation` will work for both hash and pushState based r
 
 ## Using a different pathname root
 
-`can-route-pushstate` has one additional property, [can-route-pushstate.prototype.root], which specifies the part of that pathname that should not change. For example, if we only want to have pathnames within `http://example.com/contacts/`, we can specify a root like:
+`RoutePushstate` has an additional property, [can-route-pushstate.prototype.root], which specifies the part of that pathname that should not change. For example, if we only want to have pathnames within `http://example.com/contacts/`, we can specify a root like:
 
 ```js
 import { route, RoutePushstate } from "can";

--- a/can-route-pushstate.md
+++ b/can-route-pushstate.md
@@ -18,7 +18,7 @@
   <mock-url pushstate:from="true"></mock-url>
   <script type="module">
   import {route, RoutePushstate} from "can";
-  import "https://unpkg.com/mock-url@^5.1";
+  import "//unpkg.com/mock-url@^5.1.1-rc1";
 
   route.urlData = new RoutePushstate();
 
@@ -46,7 +46,7 @@ To create routes use [can-route.register `route.register()`] like:
 <mock-url pushstate:from="true"></mock-url>
 <script type="module">
 import {route, RoutePushstate} from "can";
-import "https://unpkg.com/mock-url@^5.1";
+import "//unpkg.com/mock-url@^5.1.1-rc1";
 
 route.urlData = new RoutePushstate();
 
@@ -104,7 +104,7 @@ In this next example clicking the back button in our mock-url shows the path as 
 <mock-url pushstate:from="true"></mock-url>
 <script type="module">
 import { route, RoutePushstate } from "can";
-import "//unpkg.com/mock-url@^5.1";
+import "//unpkg.com/mock-url@^5.1.1-rc1";
 
 route.urlData = new RoutePushstate();
 route.register("{page}");
@@ -141,7 +141,7 @@ The behavior can be configured to occur only once for a specific property using 
 <mock-url pushstate:from="true"></mock-url>
 <script type="module">
 import { route, RoutePushstate } from "can";
-import "//unpkg.com/mock-url@^5.1";
+import "//unpkg.com/mock-url@^5.1.1-rc1";
 
 route.urlData = new RoutePushstate();
 route.register("{page}");

--- a/can-route-pushstate.md
+++ b/can-route-pushstate.md
@@ -8,22 +8,21 @@
 
 @type {RoutePushstate}
 
-  __can-route-pushstate__ exports a `RoutePushstate` constructor function that configures [can-route] to use
-  [pushState](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history)
+  __can-route-pushstate__ exports a `RoutePushstate` constructor function. That constructor function can be used to create an observable that can be used with [can-route]. It configures [can-route] to use [pushState](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history)
   to change the window's [pathname](https://developer.mozilla.org/en-US/docs/Web/API/URLUtils.pathname) instead
   of the [hash](https://developer.mozilla.org/en-US/docs/Web/API/URLUtils.hash).
 
-  __can-route-pushstate__ exports an observable that can be used with [can-route]. To start using can-route-pushstate set the [can-route.urlData route.urlData] property:
+  To start using can-route-pushstate set the [can-route.urlData route.urlData] property:
 
   ```html
-  <mock-url pushstate:raw="true"></mock-url>
+  <mock-url pushstate:from="true"></mock-url>
   <script type="module">
   import {route, RoutePushstate} from "can";
-  import "https://unpkg.com/mock-url@next";
+  import "https://unpkg.com/mock-url@^5.1";
 
   route.urlData = new RoutePushstate();
 
-  route.register( "{page}", { page: "homepage" } );
+  route.register( "{page}" );
   route.register( "contacts/{username}" );
 
   route.start(); // Initializes can-route
@@ -44,14 +43,14 @@
 To create routes use [can-route.register `route.register()`] like:
 
 ```html
-<mock-url pushstate:raw="true"></mock-url>
+<mock-url pushstate:from="true"></mock-url>
 <script type="module">
 import {route, RoutePushstate} from "can";
-import "https://unpkg.com/mock-url@next";
+import "https://unpkg.com/mock-url@^5.1";
 
 route.urlData = new RoutePushstate();
 
-route.register( "{page}", { page: "homepage" } );
+route.register( "{page}" );
 route.register( "contacts/{username}" );
 route.register( "books/{genre}/{author}" );
 
@@ -102,10 +101,10 @@ Enable the behavior by calling `replaceStateOn` with specified route property ke
 In this next example clicking the back button in our mock-url shows the path as _search_ -> _projects_ -> _home_, because [can-route-pushstate.prototype.replaceStateOn] was called when _projects_ was set, instead of creating a new history record the previous one was updated. [can-route-pushstate.prototype.replaceStateOff] was called before setting `route.data.page` to _search_, and a new record was created:
 
 ```html
-<mock-url pushstate:raw="true"></mock-url>
+<mock-url pushstate:from="true"></mock-url>
 <script type="module">
 import { route, RoutePushstate } from "can";
-import "//unpkg.com/mock-url@next";
+import "//unpkg.com/mock-url@^5.1";
 
 route.urlData = new RoutePushstate();
 route.register("{page}");
@@ -139,10 +138,10 @@ setTimeout(() => {
 The behavior can be configured to occur only once for a specific property using [can-route-pushstate.prototype.replaceStateOnce] like:
 
 ```html
-<mock-url pushstate:raw="true"></mock-url>
+<mock-url pushstate:from="true"></mock-url>
 <script type="module">
 import { route, RoutePushstate } from "can";
-import "//unpkg.com/mock-url@next";
+import "//unpkg.com/mock-url@^5.1";
 
 route.urlData = new RoutePushstate();
 route.register("{page}");

--- a/docs/replaceStateOff.md
+++ b/docs/replaceStateOff.md
@@ -13,7 +13,7 @@
   <mock-url pushstate:from="true"></mock-url>
   <script type="module">
   import { route, RoutePushstate } from "can";
-  import "//unpkg.com/mock-url@^5.1";
+  import "//unpkg.com/mock-url@^5.1.1-rc1";
 
   route.urlData = new RoutePushstate();
   route.register("{page}");

--- a/docs/replaceStateOff.md
+++ b/docs/replaceStateOff.md
@@ -10,10 +10,10 @@
   In the example clicking the `mock-url` back button will shows the path as _search_ -> _projects_ -> _home_ as setting _projects_ changed the previous history entry instead of creating a new one.
 
   ```html
-  <mock-url pushstate:raw="true"></mock-url>
+  <mock-url pushstate:from="true"></mock-url>
   <script type="module">
   import { route, RoutePushstate } from "can";
-  import "//unpkg.com/mock-url@next";
+  import "//unpkg.com/mock-url@^5.1";
 
   route.urlData = new RoutePushstate();
   route.register("{page}");

--- a/docs/replaceStateOff.md
+++ b/docs/replaceStateOff.md
@@ -1,0 +1,47 @@
+@function can-route-pushstate.prototype.replaceStateOff replaceStateOff
+@parent can-route-pushstate.prototype
+
+@description Restores default [can-route-pushstate] behavior that was changed by [can-route-pushstate.prototype.replaceStateOn].
+
+@signature `push.replaceStateOff( key )`
+
+  `replaceStateOff` restores the default behavior of route parameter keys changed by [can-route-pushstate.prototype.replaceStateOn `replaceStateOn`]. changes to route property keys previously passed to `replaceStateOn` will start creating new history entries.
+
+  In the example clicking the `mock-url` back button will shows the path as _search_ -> _projects_ -> _home_ as setting _projects_ changed the previous history entry instead of creating a new one.
+
+  ```html
+  <mock-url pushstate:raw="true"></mock-url>
+  <script type="module">
+  import { route, RoutePushstate } from "can";
+  import "//unpkg.com/mock-url@next";
+
+  route.urlData = new RoutePushstate();
+  route.register("{page}");
+  route.start();
+
+  // New history record is created
+  route.data.set( "page", "home" );
+
+  // Dashboard will not show up when you click back
+  setTimeout(() => {
+    // New history record is created
+    route.data.set( "page", "dashboard" );
+  }, 100);
+
+  setTimeout(() => {
+    // Mutates the previous history record
+    route.urlData.replaceStateOn( "page" );
+    route.data.set( "page", "projects" );
+  }, 200)
+
+  setTimeout(() => {
+    // New history record is created
+    route.urlData.replaceStateOff( "page" );
+    route.data.set( "page", "search" );
+  }, 300);
+  </script>
+  ```
+  @codepen
+  @highlight 27
+
+  @param {String} key A [can-route.data] property key.

--- a/docs/replaceStateOn.md
+++ b/docs/replaceStateOn.md
@@ -1,0 +1,49 @@
+@function can-route-pushstate.prototype.replaceStateOn replaceStateOn
+@parent can-route-pushstate.prototype
+
+@description Allows changes to the current route state without creating new history entries.
+
+@signature `push.replaceStateOn( key )`
+
+  `replaceStateOn` changes the behavior of [can-route-pushstate] from using [pushState](https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method) to [can-route-pushstate.prototype.replaceState](https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_replaceState()_method) for the provided route property `key`s. This allows for changes to the specified routes without creating new history entries.
+
+  In the example clicking the `mock-url` back button will shows the path as _search_ -> _projects_ -> _home_ as setting _projects_ changed the previous history entry instead of creating a new one.
+
+  ```html
+  <mock-url pushstate:raw="true"></mock-url>
+  <script type="module">
+  import { route, RoutePushstate } from "can";
+  import "//unpkg.com/mock-url@next";
+
+  route.urlData = new RoutePushstate();
+  route.register("{page}");
+  route.start();
+
+  // New history record is created
+  route.data.set( "page", "home" );
+
+  // Dashboard will not show up when you click back
+  setTimeout(() => {
+    // New history record is created
+    route.data.set( "page", "dashboard" );
+  }, 100);
+
+  setTimeout(() => {
+    // Mutates the previous history record
+    route.urlData.replaceStateOn( "page" );
+    route.data.set( "page", "projects" );
+  }, 200)
+
+  setTimeout(() => {
+    // New history record is created
+    route.urlData.replaceStateOff( "page" );
+    route.data.set( "page", "search" );
+  }, 300);
+  </script>
+  ```
+  @codepen
+  @highlight 21
+
+  Use [can-route-pushstate.prototype.replaceStateOff] to return the routes to default [can-route-pushstate] behavior.
+
+  @param {String} key A [can-route.data] property key.

--- a/docs/replaceStateOn.md
+++ b/docs/replaceStateOn.md
@@ -13,7 +13,7 @@
   <mock-url pushstate:from="true"></mock-url>
   <script type="module">
   import { route, RoutePushstate } from "can";
-  import "//unpkg.com/mock-url@^5.1";
+  import "//unpkg.com/mock-url@^5.1.1-rc1";
 
   route.urlData = new RoutePushstate();
   route.register("{page}");

--- a/docs/replaceStateOn.md
+++ b/docs/replaceStateOn.md
@@ -10,10 +10,10 @@
   In the example clicking the `mock-url` back button will shows the path as _search_ -> _projects_ -> _home_ as setting _projects_ changed the previous history entry instead of creating a new one.
 
   ```html
-  <mock-url pushstate:raw="true"></mock-url>
+  <mock-url pushstate:from="true"></mock-url>
   <script type="module">
   import { route, RoutePushstate } from "can";
-  import "//unpkg.com/mock-url@next";
+  import "//unpkg.com/mock-url@^5.1";
 
   route.urlData = new RoutePushstate();
   route.register("{page}");

--- a/docs/replaceStateOnce.md
+++ b/docs/replaceStateOnce.md
@@ -8,10 +8,10 @@
   `replaceStateOnce` changes the behavior of [can-route-pushstate] from using [pushState](https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method) to [replaceState](https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_replaceState()_method) for the _next_ route change. This allows for one change to the specified routes without creating new history entries.
 
   ```html
-  <mock-url pushstate:raw="true"></mock-url>
+  <mock-url pushstate:from="true"></mock-url>
   <script type="module">
   import { route, RoutePushstate } from "can";
-  import "//unpkg.com/mock-url@next";
+  import "//unpkg.com/mock-url@^5.1";
 
   route.urlData = new RoutePushstate();
   route.register("{page}");

--- a/docs/replaceStateOnce.md
+++ b/docs/replaceStateOnce.md
@@ -11,7 +11,7 @@
   <mock-url pushstate:from="true"></mock-url>
   <script type="module">
   import { route, RoutePushstate } from "can";
-  import "//unpkg.com/mock-url@^5.1";
+  import "//unpkg.com/mock-url@^5.1.1-rc1";
 
   route.urlData = new RoutePushstate();
   route.register("{page}");

--- a/docs/replaceStateOnce.md
+++ b/docs/replaceStateOnce.md
@@ -1,0 +1,39 @@
+@function can-route-pushstate.prototype.replaceStateOnce replaceStateOnce
+@parent can-route-pushstate.prototype
+
+@description Allows one change to the current route state without creating new history entries.
+
+@signature `push.replaceStateOnce( key )`
+
+  `replaceStateOnce` changes the behavior of [can-route-pushstate] from using [pushState](https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method) to [replaceState](https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_replaceState()_method) for the _next_ route change. This allows for one change to the specified routes without creating new history entries.
+
+  ```html
+  <mock-url pushstate:raw="true"></mock-url>
+  <script type="module">
+  import { route, RoutePushstate } from "can";
+  import "//unpkg.com/mock-url@next";
+
+  route.urlData = new RoutePushstate();
+  route.register("{page}");
+  route.start();
+
+  // New history record is created
+  route.data.set( "page", "home" ); 
+
+  // Dashboard will not show up when you click back
+  setTimeout(() => {
+    // New history record is created
+    route.data.set( "page", "dashboard" );
+  }, 100);
+
+  setTimeout(() => {
+    // Mutates the previous history record
+    route.urlData.replaceStateOnce( "page" );
+    route.data.set( "page", "search" );
+  }, 200);
+  </script>
+  ```
+  @codepen
+  @highlight 21
+
+  @param {String} key A [can-route.data] property key.

--- a/docs/root.md
+++ b/docs/root.md
@@ -1,0 +1,41 @@
+@property {String} can-route-pushstate.prototype.root root
+@parent can-route-pushstate.prototype
+
+@description Configure the base url that will not be modified.
+
+@option {String} Represents the base url that pushstate will prepend to all
+routes.  `root` defaults to: `"/"`.
+
+@body
+
+## Use
+
+By default, a route like:
+
+```js
+route.urlData = new RoutePushstate();
+route.register( "{type}/{id}" );
+```
+
+Matches URLs like:
+
+```
+http://domain.com/contact/5
+```
+
+But sometimes, you only want to match pages within a certain directory.  For
+example, an application that is a filemanager.  You might want to
+specify root and routes like:
+
+```js
+route.urlData = new RoutePushstate();
+route.urlData.root = "/filemanager/";
+route.register( "file-{fileId}" );
+route.register( "folder-{fileId}" );
+```
+
+Which matches URLs like:
+
+```
+http://domain.com/filemanager/file-34234
+```

--- a/docs/root.md
+++ b/docs/root.md
@@ -7,10 +7,10 @@
 routes.  `root` defaults to: `"/"`. The example below shows setting a custom root.
 
   ```html
-  <mock-url pushstate:raw="true"></mock-url>
+  <mock-url pushstate:from="true"></mock-url>
   <script type="module">
   import {route, RoutePushstate} from "can";
-  import "https://unpkg.com/mock-url@next";
+  import "https://unpkg.com/mock-url@^5.1";
 
   route.urlData = new RoutePushstate();
   route.urlData.root = "/movies/";
@@ -30,10 +30,10 @@ routes.  `root` defaults to: `"/"`. The example below shows setting a custom roo
 By default, a route like:
 
 ```html
-<mock-url pushstate:raw="true"></mock-url>
+<mock-url pushstate:from="true"></mock-url>
 <script type="module">
 import {route, RoutePushstate} from "can";
-import "https://unpkg.com/mock-url@next";
+import "https://unpkg.com/mock-url@^5.1";
 
 route.urlData = new RoutePushstate();
 route.register( "{type}/{id}" );
@@ -52,14 +52,14 @@ http://domain.com/contact/5
 ```
 
 But sometimes, you only want to match pages within a certain directory.  For
-example, an application that is a filemanager.  You might want to
+example, an application that is a file manager.  You might want to
 specify root and routes like:
 
 ```html
-<mock-url pushstate:raw="true"></mock-url>
+<mock-url pushstate:from="true"></mock-url>
 <script type="module">
 import {route, RoutePushstate} from "can";
-import "https://unpkg.com/mock-url@next";
+import "https://unpkg.com/mock-url@^5.1";
 
 route.urlData = new RoutePushstate();
 route.urlData.root = "/filemanager/";

--- a/docs/root.md
+++ b/docs/root.md
@@ -10,7 +10,7 @@ routes.  `root` defaults to: `"/"`. The example below shows setting a custom roo
   <mock-url pushstate:from="true"></mock-url>
   <script type="module">
   import {route, RoutePushstate} from "can";
-  import "https://unpkg.com/mock-url@^5.1";
+  import "//unpkg.com/mock-url@^5.1.1-rc1";
 
   route.urlData = new RoutePushstate();
   route.urlData.root = "/movies/";
@@ -33,7 +33,7 @@ By default, a route like:
 <mock-url pushstate:from="true"></mock-url>
 <script type="module">
 import {route, RoutePushstate} from "can";
-import "https://unpkg.com/mock-url@^5.1";
+import "//unpkg.com/mock-url@^5.1.1-rc1";
 
 route.urlData = new RoutePushstate();
 route.register( "{type}/{id}" );
@@ -59,7 +59,7 @@ specify root and routes like:
 <mock-url pushstate:from="true"></mock-url>
 <script type="module">
 import {route, RoutePushstate} from "can";
-import "https://unpkg.com/mock-url@^5.1";
+import "//unpkg.com/mock-url@^5.1.1-rc1";
 
 route.urlData = new RoutePushstate();
 route.urlData.root = "/filemanager/";

--- a/docs/root.md
+++ b/docs/root.md
@@ -4,7 +4,24 @@
 @description Configure the base url that will not be modified.
 
 @option {String} Represents the base url that pushstate will prepend to all
-routes.  `root` defaults to: `"/"`.
+routes.  `root` defaults to: `"/"`. The example below shows setting a custom root.
+
+  ```html
+  <mock-url pushstate:raw="true"></mock-url>
+  <script type="module">
+  import {route, RoutePushstate} from "can";
+  import "https://unpkg.com/mock-url@next";
+
+  route.urlData = new RoutePushstate();
+  route.urlData.root = "/movies/";
+  route.register("{genre}");
+
+  route.start();
+  route.data.genre = "comedy";
+  </script>
+  ```
+  @codepen
+  @highlight 7
 
 @body
 
@@ -12,10 +29,21 @@ routes.  `root` defaults to: `"/"`.
 
 By default, a route like:
 
-```js
+```html
+<mock-url pushstate:raw="true"></mock-url>
+<script type="module">
+import {route, RoutePushstate} from "can";
+import "https://unpkg.com/mock-url@next";
+
 route.urlData = new RoutePushstate();
 route.register( "{type}/{id}" );
+route.start();
+
+route.data.type = "contact";
+route.data.id = "5";
+</script>
 ```
+@codepen
 
 Matches URLs like:
 
@@ -27,12 +55,20 @@ But sometimes, you only want to match pages within a certain directory.  For
 example, an application that is a filemanager.  You might want to
 specify root and routes like:
 
-```js
+```html
+<mock-url pushstate:raw="true"></mock-url>
+<script type="module">
+import {route, RoutePushstate} from "can";
+import "https://unpkg.com/mock-url@next";
+
 route.urlData = new RoutePushstate();
 route.urlData.root = "/filemanager/";
 route.register( "file-{fileId}" );
-route.register( "folder-{fileId}" );
+route.start();
+route.data.fileId = 34234;
+</script>
 ```
+@codepen
 
 Which matches URLs like:
 


### PR DESCRIPTION
Solves the following issues from #126 

## [can-route-pushstate.html](https://www.canjs.com/doc/can-route-pushstate.html)
- [x] Codepen
- [x] Needs `@signature`(s)

## [can-route-pushstate.prototype.root.html](https://www.canjs.com/doc/can-route-pushstate.prototype.root.html)
- [x] Codepen
- [x] Needs `@signature`(s)

## pages needed
- [x] `replaceStateOff`
- [x] `replaceStateOnce`
- [x] `replaceStateOn`