### PR TITLE
using steal-with-promises for scripts loaded by canjs/canjs test suite

### DIFF
--- a/test/testing-nw.html
+++ b/test/testing-nw.html
@@ -6,8 +6,8 @@
 <body>
 <p>This is a dummy page to use<br/> for testing route goodness</p>
 
-<script type="text/javascript" src="../../../node_modules/steal/steal.js" main="@empty"></script>
 <script type="text/javascript" src="../node_modules/steal/steal.js" main="@empty"></script>
+<script type="text/javascript" src="../../../node_modules/steal/steal-with-promises.js" main="@empty"></script>
 <script>
 steal.done().then(function() {
 	Promise.all([

--- a/test/testing-ssr.html
+++ b/test/testing-ssr.html
@@ -6,8 +6,8 @@
 <body>
 <p>This is a dummy page to use<br/> for testing route goodness</p>
 
-<script type="text/javascript" src="../../../node_modules/steal/steal.js" main="@empty"></script>
 <script type="text/javascript" src="../node_modules/steal/steal.js" main="@empty"></script>
+<script type="text/javascript" src="../../../node_modules/steal/steal-with-promises.js" main="@empty"></script>
 <script>
 steal.done().then(function() {
 	Promise.all([

--- a/test/testing.html
+++ b/test/testing.html
@@ -7,8 +7,8 @@
 <p>This is a dummy page to use<br/> for testing route goodness</p>
 <span id="url"></span>
 
-<script type="text/javascript" src="../../../node_modules/steal/steal.js" main="@empty"></script>
 <script type="text/javascript" src="../node_modules/steal/steal.js" main="@empty"></script>
+<script type="text/javascript" src="../../../node_modules/steal/steal-with-promises.js" main="@empty"></script>
 <script>
 setInterval(function(){
 	document.getElementById("url").innerHTML = window.location.href;


### PR DESCRIPTION
canjs/canjs is using Steal 2.0, so we need to use the -with-promises
version of steal so tests will work in browsers without native Promises.