### PR TITLE
Fix an issue with the tests passing in IE11

### DIFF
--- a/can-route-pushstate_test.js
+++ b/can-route-pushstate_test.js
@@ -477,9 +477,11 @@ function makeTest(mapModuleName){
 
 		var a = document.createElement("a");
 		a.setAttribute("href", "/books/40");
+		document.getElementById("qunit-fixture").appendChild(a);
+
 		var event = document.createEvent('HTMLEvents');
 		event.initEvent('click', true, true);
-		
+
 		globals.setKeyValue('isNode', true);
 
 		QUnit.ok(route.urlData.shouldCallPushState(a, event), "Push state should be called");
@@ -487,7 +489,7 @@ function makeTest(mapModuleName){
 		globals.setKeyValue('global', global);
 		globals.setKeyValue('document', document);
 		globals.setKeyValue('isNode', isNode);
-		
+
 	});
 
 	test('shouldCallPushState on SVG', function(){
@@ -496,12 +498,12 @@ function makeTest(mapModuleName){
 		var isNode = globals.getKeyValue('isNode');
 
 		route.register("{type}/{id}");
-	
+
 		var a = document.createElementNS("http://www.w3.org/1999/xlink", "a");
 		var event = document.createEvent('HTMLEvents');
 		a.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", "/books/40");
 		event.initEvent('click', true, true);
-		
+
 		globals.setKeyValue('isNode', true);
 
 		QUnit.ok(route.urlData.shouldCallPushState(a, event), "Push state should be called");
@@ -509,7 +511,7 @@ function makeTest(mapModuleName){
 		globals.setKeyValue('global', global);
 		globals.setKeyValue('document', document);
 		globals.setKeyValue('isNode', isNode);
-		
+
 	});
 
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "can-queues": "^1.2.1",
     "detect-cyclic-packages": "^1.1.0",
     "docco": "^0.8.0",
+    "highlight.js": "9.12.0",
     "jshint": "^2.9.1",
     "steal": "^2.1.4",
     "steal-qunit": "^1.0.0",

--- a/test/test-ie.html
+++ b/test/test-ie.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<title>can-route-pushstate</title>
+<script src="../node_modules/steal/steal-with-promises.js" main="test/test"></script>
+<div id="qunit-fixture"></div>


### PR DESCRIPTION
The failing test was expecting that an anchor element’s `pathname` would start with `/`, but IE11 has a bug where it doesn’t include the leading `/` if the element isn’t part of the document: https://stackoverflow.com/questions/956233/javascript-pathname-ie-quirk

This fixes the issue by adding the element to the document in the test. I think this was a better solution than changing the core `can-route-pushstate` code to detect the situation, because under normal use I would only expect links to be clicked if they’re part of a document.

This PR also:

- Adds a file for testing with IE
- Works around a `highlight.js` issue https://github.com/highlightjs/highlight.js/issues/1984