### PR TITLE
Fix the tests to actually test against can-define and can-map

### DIFF
--- a/can-route-pushstate_test.js
+++ b/can-route-pushstate_test.js
@@ -11,10 +11,14 @@ if (window.history && history.pushState) {
 }
 
 function makeTest(mapModuleName){
+	var mapModuleImport = System.import(mapModuleName);
+
 	QUnit.module("can/route/pushstate with " + mapModuleName, {
 		beforeEach: function(assert) {
-			route.urlData = new RoutePushstate();
-			window.MAP_MODULE_NAME = mapModuleName;
+			return mapModuleImport.then(function(MapModule) {
+				route.data = new MapModule();
+				route.urlData = new RoutePushstate();
+			});
 		}
 	});
 

--- a/test/testing.html
+++ b/test/testing.html
@@ -27,6 +27,7 @@ steal.done().then(function() {
 		window.queues = modules[3];
 		window.ObservationRecorder = modules[4];
 
+		window.route.data = new window.CanMap();
 		window.route.urlData = new window.RoutePushstate();
 		setTimeout(function() {
 			window.parent.routeTestReady &&


### PR DESCRIPTION
The tests were written as if they were testing against both can-define and can-map. In reality, only can-define was being tested because the default route data was always used. This fixes the issue by importing the modules and always assigning `route.data`.