### PR TITLE
Upgrade can-route for CanJS 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js: 10
 services:
   - xvfb
 addons:
-  firefox: '51.0'
+  firefox: latest
   sauce_connect: true
 before_script:
   - npm run http-server &

--- a/package.json
+++ b/package.json
@@ -34,19 +34,20 @@
     "donejs"
   ],
   "dependencies": {
-    "can-diff": "<2.0.0",
+    "can-diff": "^1.0.0",
     "can-dom-events": "^1.1.0",
-    "can-globals": "<2.0.0",
+    "can-globals": "^1.0.0",
     "can-observation-recorder": "^1.0.2",
     "can-reflect": "^1.8.0",
-    "can-route": "^4.3.12",
+    "can-route": "^5.0.0-pre.0",
     "can-simple-observable": "^2.0.0",
     "can-symbol": "^1.6.3"
   },
   "devDependencies": {
-    "can-assign": "<2.0.0",
+    "can-assign": "^1.0.0",
     "can-define": "^2.6.0",
     "can-map": "^4.0.0",
+    "can-observable-object": "^1.0.0-pre.3",
     "can-queues": "^1.2.1",
     "detect-cyclic-packages": "^1.1.0",
     "docco": "^0.8.0",

--- a/test/pushstate-iframe-tests-ie.js
+++ b/test/pushstate-iframe-tests-ie.js
@@ -1,0 +1,6 @@
+import { makeTest } from "./pushstate-iframe-tests";
+
+if (window.history && history.pushState) {
+	makeTest("can-map");
+	makeTest("can-define/map/map");
+}

--- a/test/pushstate-iframe-tests-modern.js
+++ b/test/pushstate-iframe-tests-modern.js
@@ -1,0 +1,7 @@
+import { makeTest } from "./pushstate-iframe-tests";
+
+if (window.history && history.pushState) {
+	makeTest("can-map");
+	makeTest("can-define/map/map");
+	makeTest("can-observable-object");
+}

--- a/test/pushstate-iframe-tests.js
+++ b/test/pushstate-iframe-tests.js
@@ -2,14 +2,9 @@
 var domEvents = require('can-dom-events');
 var extend = require('can-assign');
 var route = require('can-route');
-var RoutePushstate = require('./can-route-pushstate');
+var RoutePushstate = require('../can-route-pushstate');
 
-if (window.history && history.pushState) {
-	makeTest("can-map");
-	makeTest("can-define/map/map");
-}
-
-function makeTest(mapModuleName){
+module.exports.makeTest = function(mapModuleName) {
 	QUnit.module("can/route/pushstate with " + mapModuleName, {
 		beforeEach: function() {
 			route.urlData = new RoutePushstate();
@@ -38,7 +33,7 @@ function makeTest(mapModuleName){
 				});
 			};
 
-			testHTML = testHTML || __dirname + "/test/testing.html";
+			testHTML = testHTML || __dirname + "/testing.html";
 			iframe.src = testHTML + "?" + Math.random();
 			document.getElementById("qunit-fixture").appendChild(iframe);
 		};
@@ -161,7 +156,7 @@ function makeTest(mapModuleName){
 
 			};
 			var iframe = document.createElement('iframe');
-			iframe.src = __dirname + "/test/testing.html?1";
+			iframe.src = __dirname + "/testing.html?1";
 			document.getElementById("qunit-fixture").appendChild(iframe);
 		});
 
@@ -203,7 +198,7 @@ function makeTest(mapModuleName){
 				}, 100);
 			};
 			var iframe = document.createElement('iframe');
-			iframe.src = __dirname + "/test/testing.html";
+			iframe.src = __dirname + "/testing.html";
 			document.getElementById('qunit-fixture').appendChild(iframe);
 		});
 
@@ -249,7 +244,7 @@ function makeTest(mapModuleName){
 
 			};
 			var iframe = document.createElement('iframe');
-			iframe.src = __dirname + "/test/testing.html#thisIsMyHash";
+			iframe.src = __dirname + "/testing.html#thisIsMyHash";
 			document.getElementById('qunit-fixture').appendChild(iframe);
 		});
 
@@ -290,7 +285,7 @@ function makeTest(mapModuleName){
 				iframe.parentNode.removeChild(iframe);
 			};
 			var iframe = document.createElement('iframe');
-			iframe.src = __dirname + "/test/testing.html";
+			iframe.src = __dirname + "/testing.html";
 			document.getElementById('qunit-fixture').appendChild(iframe);
 		});
 
@@ -477,7 +472,7 @@ function makeTest(mapModuleName){
 				};
 
 				var iframe = document.createElement("iframe");
-				iframe.src = __dirname + "/test/testing.html";
+				iframe.src = __dirname + "/testing.html";
 				document.getElementById('qunit-fixture').appendChild(iframe);
 			});
 
@@ -693,7 +688,7 @@ function makeTest(mapModuleName){
 				assert.equal(info.route.defaultBinding, "hashchange", "using hashchange routing");
 				cleanup();
 				done();
-			}, __dirname + "/test/testing-nw.html");
+			}, __dirname + "/testing-nw.html");
 		});
 
 		QUnit.test("Binding is added if there is no protocol (can-simple-dom uses an empty string as the protocol)", function(assert) {
@@ -703,7 +698,7 @@ function makeTest(mapModuleName){
 				assert.ok(true, "We got this far which means things did not blow up");
 				cleanup();
 				done();
-			}, __dirname + "/test/testing-ssr.html");
+			}, __dirname + "/testing-ssr.html");
 		});
 
 		QUnit.test("Calling route.stop() works", function(assert) {

--- a/test/pushstate-tests-ie.js
+++ b/test/pushstate-tests-ie.js
@@ -1,0 +1,6 @@
+import { makeTest } from "./pushstate-tests";
+
+if (window.history && history.pushState) {
+	makeTest("can-map");
+	makeTest("can-define/map/map");
+}

--- a/test/pushstate-tests-modern.js
+++ b/test/pushstate-tests-modern.js
@@ -1,0 +1,7 @@
+import { makeTest } from "./pushstate-tests";
+
+if (window.history && history.pushState) {
+	makeTest("can-map");
+	makeTest("can-define/map/map");
+	makeTest("can-observable-object");
+}

--- a/test/pushstate-tests.js
+++ b/test/pushstate-tests.js
@@ -1,16 +1,10 @@
 /* jshint asi:true,scripturl:true */
 var QUnit = require('steal-qunit');
-var RoutePushstate = require('./can-route-pushstate');
+var RoutePushstate = require('../can-route-pushstate');
 var route = require('can-route');
-require("./can-route-pushstate-iframe-test");
 var globals = require('can-globals');
 
-if (window.history && history.pushState) {
-	makeTest("can-map");
-	makeTest("can-define/map/map");
-}
-
-function makeTest(mapModuleName){
+module.exports.makeTest = function(mapModuleName) {
 	var mapModuleImport = System.import(mapModuleName);
 
 	QUnit.module("can/route/pushstate with " + mapModuleName, {

--- a/test/test-ie.html
+++ b/test/test-ie.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
 <title>can-route-pushstate</title>
-<script src="../node_modules/steal/steal-with-promises.js" main="test/test"></script>
+<script>
+	steal = {
+		paths: {
+			"can-route/src/routedata": "node_modules/can-route/src/routedata-definemap.js"
+		}
+	};
+</script>
+<script src="../node_modules/steal/steal-with-promises.js" main="test/test-ie"></script>
 <div id="qunit-fixture"></div>

--- a/test/test-ie.js
+++ b/test/test-ie.js
@@ -1,0 +1,2 @@
+import './pushstate-tests-ie';
+import './pushstate-iframe-tests-ie';

--- a/test/test.js
+++ b/test/test.js
@@ -1,1 +1,2 @@
-import '../can-route-pushstate_test';
+import './pushstate-tests-modern';
+import './pushstate-iframe-tests-modern';

--- a/test/testing-nw.html
+++ b/test/testing-nw.html
@@ -6,8 +6,24 @@
 <body>
 <p>This is a dummy page to use<br/> for testing route goodness</p>
 
-<script type="text/javascript" src="../node_modules/steal/steal.js" main="@empty"></script>
+<script>
+	steal = {
+		paths: {
+			"can-route/src/routedata": "node_modules/can-route/src/routedata-definemap.js"
+		}
+	};
+</script>
+<script type="text/javascript" src="../node_modules/steal/steal-with-promises.js" main="@empty"></script>
+
+<script>
+	steal = {
+		paths: {
+			"can-route/src/routedata": "node_modules/can-route/src/routedata-definemap.js"
+		}
+	};
+</script>
 <script type="text/javascript" src="../../../node_modules/steal/steal-with-promises.js" main="@empty"></script>
+
 <script>
 steal.done().then(function() {
 	Promise.all([

--- a/test/testing-ssr.html
+++ b/test/testing-ssr.html
@@ -6,8 +6,24 @@
 <body>
 <p>This is a dummy page to use<br/> for testing route goodness</p>
 
-<script type="text/javascript" src="../node_modules/steal/steal.js" main="@empty"></script>
+<script>
+	steal = {
+		paths: {
+			"can-route/src/routedata": "node_modules/can-route/src/routedata-definemap.js"
+		}
+	};
+</script>
+<script type="text/javascript" src="../node_modules/steal/steal-with-promises.js" main="@empty"></script>
+
+<script>
+	steal = {
+		paths: {
+			"can-route/src/routedata": "node_modules/can-route/src/routedata-definemap.js"
+		}
+	};
+</script>
 <script type="text/javascript" src="../../../node_modules/steal/steal-with-promises.js" main="@empty"></script>
+
 <script>
 steal.done().then(function() {
 	Promise.all([

--- a/test/testing.html
+++ b/test/testing.html
@@ -7,8 +7,24 @@
 <p>This is a dummy page to use<br/> for testing route goodness</p>
 <span id="url"></span>
 
-<script type="text/javascript" src="../node_modules/steal/steal.js" main="@empty"></script>
+<script>
+	steal = {
+		paths: {
+			"can-route/src/routedata": "node_modules/can-route/src/routedata-definemap.js"
+		}
+	};
+</script>
+<script type="text/javascript" src="../node_modules/steal/steal-with-promises.js" main="@empty"></script>
+
+<script>
+	steal = {
+		paths: {
+			"can-route/src/routedata": "node_modules/can-route/src/routedata-definemap.js"
+		}
+	};
+</script>
 <script type="text/javascript" src="../../../node_modules/steal/steal-with-promises.js" main="@empty"></script>
+
 <script>
 setInterval(function(){
 	document.getElementById("url").innerHTML = window.location.href;


### PR DESCRIPTION
Also add `can-observable-object` to the test suite.

Part of https://github.com/canjs/canjs/issues/5207